### PR TITLE
Fix Plotly jquery dependency

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="shortcut icon" href="img/icon_small.ico">
   <script src="scripts/d3.min.js"></script>
+  <script src="scripts/jquery-2.1.4.min.js"></script>
   <script src="scripts/plotly-basic.js"></script>
   <script src="https://unpkg.com/vue@3"></script>
 </head>


### PR DESCRIPTION
## Summary
- add jquery script to include `window.$` before plotly loads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841f6bbae708331a8a4c1b964097965