### PR TITLE
Speed up integration with web worker

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -25,6 +25,7 @@ createApp({
     const autoRunning = ref(false);
     let intervalHandle = null;
     let grid = null;
+    let worker = null;
 
     const createGrid = () => {
       grid = new WholeGrid({
@@ -48,6 +49,26 @@ createApp({
       grid.baseState_OneDimension_Initialization();
       grid.perturbation_Initialization_Cold();
       grid.newPlot();
+      if (worker) {
+        worker.postMessage({ cmd: 'init', params: {
+          radz: params.value.radz,
+          zcnt: params.value.zcnt,
+          KZ: params.value.KZ,
+          delta: params.value.delta,
+          bg_profile: params.value.bg_profile,
+          radx: params.value.radx,
+          imid: params.value.imid,
+          KX: params.value.KX,
+          sfc_temp: params.value.sfc_temp,
+          top_temp: params.value.top_temp,
+          DX: params.value.DX,
+          DZ: params.value.DZ,
+          NX: params.value.NX,
+          NZ: params.value.NZ,
+          DT: params.value.DT,
+          viewT: viewT.value,
+        }});
+      }
     };
 
     const updateParameter = () => {
@@ -63,9 +84,9 @@ createApp({
     };
 
     const runStep = () => {
-      if (!grid) return;
+      if (!grid || !worker) return;
       progressVisible.value = true;
-      pressRun(grid, 99, p => progress.value = p, () => progressVisible.value = false);
+      worker.postMessage({cmd: 'run', iter: 99});
     };
 
     const autoRun = () => {
@@ -79,6 +100,21 @@ createApp({
     };
 
     onMounted(() => {
+      worker = new Worker('scripts/integrationWorker.js');
+      worker.onmessage = e => {
+        if (e.data.cmd === 'progress') {
+          progress.value = e.data.value;
+        } else if (e.data.cmd === 'done') {
+          progress.value = 100;
+          progressVisible.value = false;
+          if (grid) {
+            grid.realT = e.data.realT;
+            grid.th = e.data.th;
+            grid.currentTime = e.data.time;
+            grid.newPlot();
+          }
+        }
+      };
       createGrid();
     });
 

--- a/scripts/integrationWorker.js
+++ b/scripts/integrationWorker.js
@@ -1,0 +1,24 @@
+importScripts('model.js');
+
+let grid = null;
+
+self.onmessage = function(e) {
+  const data = e.data;
+  if (data.cmd === 'init') {
+    grid = new WholeGrid(data.params);
+    grid.baseState_OneDimension_Initialization();
+    grid.perturbation_Initialization_Cold();
+    self.postMessage({cmd: 'inited'});
+  } else if (data.cmd === 'run' && grid) {
+    pressRun(grid, data.iter, progress => {
+      self.postMessage({cmd: 'progress', value: progress});
+    }, () => {
+      self.postMessage({
+        cmd: 'done',
+        realT: grid.realT,
+        th: grid.th,
+        time: grid.currentTime
+      });
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- offload heavy integration loops to a new `integrationWorker.js`
- update front-end logic to communicate with the worker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f6f288290833186193dc8467f98ce